### PR TITLE
Copy Openssl dlls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ if (WIN32)
 
     add_custom_command(TARGET sielo-browser POST_BUILD
             COMMAND ${QT5_WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_SOURCE_DIR} $<TARGET_FILE_DIR:sielo-browser>)
+			file(GLOB OPENSSL_CRYPTO_DLLS "${CMAKE_SOURCE_DIR}/third-party/openssl/windows/x64/bin/*.dll")
+			file(COPY ${OPENSSL_CRYPTO_DLLS} DESTINATION Release)
 
 
 elseif(APPLE)


### PR DESCRIPTION
for the Lazzy ones out there copyies OpenSSL crypto dlls to the release folder so you dont have to manually add them.