### PR TITLE
Fixing compilation bug

### DIFF
--- a/Core/Plugins/Plugins.hpp
+++ b/Core/Plugins/Plugins.hpp
@@ -93,9 +93,7 @@ private:
 
 	bool m_pluginsLoaded{false};
 };
-
-Q_DECLARE_METATYPE(Plugins::Plugin)
-
 }
-
+Q_DECLARE_METATYPE(Sn::Plugins::Plugin)
+	
 #endif // CORE_PLUGINS_HPP


### PR DESCRIPTION
If Plugins is in a namespace, the Q_DECLARE_METATYPE() macro has to be outside the namespace:

(doc : http://doc.qt.io/qt-5/qmetatype.html#Q_DECLARE_METATYPE)